### PR TITLE
Use opt-level=1 by default for dev.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ path = "src/wasmfilter.rs"
 [dependencies]
 rmp = "0.8.14"
 rmpv = "1.3.0"
+
+[profile.dev]
+opt-level = 1


### PR DESCRIPTION
As noted in the Makefile, the default debug mode (opt-level=0) is extraordinarily wasteful of stack space. The obvious thing to try is inlining the `rmpv::encode::write_value()` call (and the `match` therein):
```rs
pub extern "C" fn hello_world__msgpack(
    tag: *const c_char,    // uint_32 from fluentbit, presumably "wasm-address-space" 32-bit pointer
    tag_len: usize,        // size_t from fluentbit - so possibly downcast??
    tim_sec: u32,          // long int from time.h, presumably downcast?
    time_ncsec: u32,       // long int from time.h, presumably downcast?
    record: *const c_char, // uint_32 from fluentbit, presumably "wasm-address-space" 32-bit pointer
    record_len: usize      // size_t from fluentbit - so possibly downcast??
    ) -> *const c_char {
    let mut output_buf = Vec::new();
    rmp::encode::write_map_len(&mut output_buf, 1).unwrap();
    for (key, value) in vec![
        (MsgpackValue::String("msg".to_string().into()),
         MsgpackValue::String("Hello world".to_string().into()))
    ] {
        rmpv::encode::write_value(&mut output_buf, &key).unwrap();
        rmpv::encode::write_value(&mut output_buf, &value).unwrap();

    }
    output_buf.leak().as_ptr() as *const c_char
}
```
However, this still doesn't work, so it seems the `for` loop is also quite wasteful of stack space. The following does work:
```rs
pub extern "C" fn hello_world__msgpack(
    tag: *const c_char,    // uint_32 from fluentbit, presumably "wasm-address-space" 32-bit pointer
    tag_len: usize,        // size_t from fluentbit - so possibly downcast??
    tim_sec: u32,          // long int from time.h, presumably downcast?
    time_ncsec: u32,       // long int from time.h, presumably downcast?
    record: *const c_char, // uint_32 from fluentbit, presumably "wasm-address-space" 32-bit pointer
    record_len: usize      // size_t from fluentbit - so possibly downcast??
    ) -> *const c_char {
    let mut output_buf = Vec::new();
    rmp::encode::write_map_len(&mut output_buf, 1).unwrap();
    rmpv::encode::write_value(&mut output_buf, &"msg".into()).unwrap();
    rmpv::encode::write_value(&mut output_buf, &"Hello world from rust wasm! In msgpack!".into()).unwrap();
    output_buf.leak().as_ptr() as *const c_char
}
```
Ultimately, a more sustainable approach is simply to turn on a low level of optimisation in debug mode. According to LLVM documentation, O1 (equivalent to `rustc -C opt-level=1`) will "Optimize quickly without destroying debuggability." In practice this is usually safe, and solves our issue here.